### PR TITLE
k8s: Add spotty tolerations

### DIFF
--- a/deployment.yaml
+++ b/deployment.yaml
@@ -14,6 +14,11 @@ spec:
       labels:
         app: cert-alert
     spec:
+      tolerations:
+      - key: "spotty"
+        value: "true"
+        operator: "Equal"
+        effect: "NoSchedule"
       containers:
       - name: cert-alert
         image: directangular/cert-alert


### PR DESCRIPTION
So it can run on directangular spot instances